### PR TITLE
Expose gaps commands as library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+module.exports.init = require('./lib/commands/init');
+module.exports.download = require('./lib/commands/download');
+module.exports.upload = require('./lib/commands/upload');

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -1,18 +1,21 @@
 var Q = require('q');
+var _ = require('underscore');
 var request = require('request');
 var google = require('googleapis');
 var authenticate = require('../utils/authenticate');
-var clone = require('../utils/clone')
+var clone = require('../utils/clone');
 var config = require('../config');
 var error = moduleErrors();
 
 var DOWNLOAD_URL = 'https://script.google.com/feeds/download/export?format=json&id=';
 
-module.exports = function(fileId) {
-  getProjectById(fileId)
-    .then(clone)
-    .then(function() {
-      console.log('All done!')
+module.exports = function(fileId, dest) {
+  dest = _.isString(dest) ? dest : null;
+  return getProjectById(fileId)
+    .then(_(clone).partial(_, dest))
+    .then(function(project) {
+      console.log('All done!');
+      return project;
     })
     .catch(function(err) {
       console.log('Error running download command', err);
@@ -23,7 +26,7 @@ function getProjectById(fileId) {
   var project = {};
   var deferred = Q.defer();
   authenticate().then(function(auth) {
-    return Q.all([getProjectTitle(fileId, auth), getProjectFiles(fileId, auth)])
+    return Q.all([getProjectTitle(fileId, auth), getProjectFiles(fileId, auth)]);
   })
   .spread(function(title, files) {
     project.title = title;
@@ -53,7 +56,11 @@ function getProjectFiles(fileId, auth) {
   };
   request.get(options, function(err, res, body) {
     if (err) return deferred.reject(err);
-    var project = JSON.parse(body)
+    try {
+      var project = JSON.parse(body);
+    } catch (e) {
+      return deferred.reject(e);
+    }
     if (!project.files) return deferred.reject(error.noFiles);
     deferred.resolve(project.files);
   });

--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -1,5 +1,6 @@
 var Q = require('q');
 var fs = require('fs');
+var _ = require('underscore');
 var path = require('path');
 var google = require('googleapis');
 var authenticate = require('../utils/authenticate');
@@ -7,13 +8,14 @@ var updateManifest = require('../utils/manifestor');
 var config = require('../config');
 var error = moduleErrors();
 
-module.exports = function() {
-  console.log('Pushing back up to Google Drive...');
-  getManifestFromProject(process.cwd())
+module.exports = function(path) {
+  var projectPath = _.isString(path) ? path : process.cwd();
+  console.log('Pushing ' + projectPath + ' back up to Google Drive...');
+  return getManifestFromProject(projectPath)
     .then(updateManifest)
     .then(sendToGoogle)
     .then(function() {
-      console.log('Great success!')
+      console.log('Great success!');
     })
     .catch(function(err) {
       console.log('Error running upload command', err);
@@ -26,6 +28,7 @@ function getManifestFromProject(projectPath) {
     if (err) return deferred.reject(err);
 
     var manifest = JSON.parse(res);
+    manifest.path = projectPath;
     if (!manifest.files) return deferred.reject(error.wrongManifest);
     deferred.resolve(manifest)
   });

--- a/lib/utils/clone.js
+++ b/lib/utils/clone.js
@@ -3,11 +3,12 @@ var fs = require('fs');
 var path = require('path');
 var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
+var _ = require('underscore');
 var config = require('../config');
 
 // Updates local copy of Google Apps Script project contents
-module.exports = function(project) {
-  return removeExistingProject(project)
+module.exports = function(project, dest) {
+  return removeExistingProject(project, dest)
     .then(createProjectFolder)
     .then(writeManifest)
     .then(addProjectFiles)
@@ -16,9 +17,9 @@ module.exports = function(project) {
     });
 };
 
-function removeExistingProject(project) {
+function removeExistingProject(project, dest) {
   var deferred = Q.defer();
-  var destination = config.CLONE_DESTINATION_BASE || process.cwd();
+  var destination = dest || config.CLONE_DESTINATION_BASE || process.cwd();
   var filepath = path.join(destination, project.title);
   // TODO: Confirm if path already exists
   rimraf(filepath, function(err) {
@@ -60,7 +61,8 @@ function addProjectFiles(project) {
     });
     return deferred.promise;
   });
-  return Q.all(writeFilePromises);
+  return Q.all(writeFilePromises)
+	  .then(_.constant(project));
 }
 
 function getFileExtension(file) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "bin": {
     "gaps": "./bin/gaps"
   },
+  "main": "index",
   "preferGlobal": true,
   "keywords": [
     "google",
@@ -39,7 +40,8 @@
     "node-dir": "^0.1.6",
     "q": "^1.2.0",
     "request": "^2.54.0",
-    "rimraf": "^2.3.2"
+    "rimraf": "^2.3.2",
+    "underscore": "^1.8.3"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Expose init, download, and upload functions so gaps can be used in other
javascript programs.

Update clone and download functions to take an optional destination
directory.  Update download function to return the project object so the
path to the actual project, based on the project's name, can be
retrieved.

Update upload function to take an optional source directory.  When
uploading, set path in the manifest to the actual path in case the
directory has been moved and the path inside the manifest file is no
longer correct.
