### PR TITLE
Add current remote file list back into manifestor inputs

### DIFF
--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -24,10 +24,10 @@ module.exports = function upload() {
       return sendToGoogle(files, fileId);
     })
     .then(function() {
-      console.log('Great success!'.green);
+      console.log('The latest files were uploaded to your Apps Script project.'.green);
     })
     .catch(function(err) {
-      console.log('Error running upload command'.red);
+      console.log('Upload failed.'.red);
     });
 };
 
@@ -50,8 +50,8 @@ function sendToGoogle(files, id) {
 
       return Promise.promisify(drive.files.update)(options)
         .catch(function(err) {
+          console.log('An error occured while running upload command:'.red);
           console.log(err);
-          console.log('Google Drive returned a fatal error.'.red);
           throw err;
         });
     });

--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -17,7 +17,9 @@ module.exports = function upload() {
       fileId = config.fileId;
       return manifestor.getExternalFiles(fileId)
     })
-    .then(manifestor.build)
+    .then(function(externalFiles) {
+      return manifestor.build(externalFiles);
+    })
     .then(function(files) {
       return sendToGoogle(files, fileId);
     })
@@ -48,6 +50,7 @@ function sendToGoogle(files, id) {
 
       return Promise.promisify(drive.files.update)(options)
         .catch(function(err) {
+          console.log(err);
           console.log('Google Drive returned a fatal error.'.red);
           throw err;
         });

--- a/lib/util.js
+++ b/lib/util.js
@@ -40,11 +40,11 @@ function updateFileSource(existingFile, newFile) {
 }
 
 function hasFileOnDisk(filesOnDisk, file) {
-  _.any(filesOnDisk, function(fileOnDisk) {
+  return _.any(filesOnDisk, function(fileOnDisk) {
     var sameName = file.name === fileOnDisk.name;
     var sameType = file.type === getFileType(fileOnDisk);
     return sameName && sameType;
-  })
+  });
 }
 
 function getFileType(file) {


### PR DESCRIPTION
The upload command was not passing in the list of external files to
manifestor#build, which meant that every local file was being treated
as new. Drive throws an exception when a file with no ID that also
matches a name in the existing file is included in the manifest.
