### PR TITLE
Reject file ID on `gapps init` when ID begins with M

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -10,7 +10,11 @@ var manifestor = require('../manifestor');
 
 module.exports = function init(fileId, options) {
   var subdir = options.subdir || defaults.DEFAULT_SUBDIR;
-
+  
+  if(!fileIdIsValid(fileId)) {
+    return;
+  }
+  
   var config = {
     path: subdir,
     fileId: fileId,
@@ -47,4 +51,16 @@ function writeExternalFile(file, dir) {
       console.log('Could not write file ' + filename);
       throw err;
     })
+}
+
+function fileIdIsValid(fileId) {
+  if(fileId.charAt(0).toLowerCase() === 'm') {
+    console.log('\nScript file ID error.'.red + '\n' + 
+        'It looks like you are passing in a Project Key, from "File --> Project properties",' +
+        'rather than a Drive File ID.\nYou will find the Drive File ID in the script\'s URL:\n' +
+        'https://script.google.com/a/google.com/d/' + '__DRIVE_FILE_ID__'.green + '/edit.\n');
+     return false;
+  } else {
+     return true;
+  } 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-google-apps-script",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "The easiest way to develop Google Apps Script projects",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds simple validation to weed out Project Keys. All project keys begin with "M", Drive File IDs never do.  

From #34.
