### PR TITLE
Close connection to avoid waiting for timeout

### DIFF
--- a/lib/miniOAuthServer.js
+++ b/lib/miniOAuthServer.js
@@ -22,7 +22,10 @@ module.exports = function createOAuthServer(port) {
       res.write('You\'ve been authenticated with Google Drive! You may close this page.');
       res.write('</body>');
       res.write('</html>');
+      res.end();
+      
       server.close();
+      req.socket.destroy();
     });
 
     server.listen(port);


### PR DESCRIPTION
When using `node-google-apps-script` as a module dependency, I'd like to have the `auth` command return immediately after the user has logged in.

This is currently impossible since the `http` server uses keep-alive connections, that aren't immediately terminated when doing `server.close()`.

The solution, [used by the `http-shutdown` module](https://github.com/thedillonb/http-shutdown/blob/master/index.js#L21) is to close the socket underlying the `IncomingMessage` request.
