### PR TITLE
Use 'googleapis.drive' instead of 'request' for getting script contents

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,7 +3,6 @@ module.exports = {
   STORAGE_FILE: getUserHome() + '/.gapps',
   CONFIG_NAME: 'gapps.config.json',
   WEBSERVER_PORT: 2386,
-  DOWNLOAD_URL: 'https://script.google.com/feeds/download/export?format=json&id='
 };
 
 function getUserHome() {

--- a/lib/manifestor.js
+++ b/lib/manifestor.js
@@ -4,7 +4,7 @@ var colors = require('colors');
 
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
-var request = Promise.promisifyAll(require('request'));
+var google = require('googleapis');
 
 var util = require('./util');
 var defaults = require('./defaults');
@@ -67,17 +67,18 @@ function getExternalFiles(fileId) {
 
 
 function getProjectFiles(fileId, auth) {
+  var drive = google.drive({ version: 'v3', auth });
   var options = {
-    url: defaults.DOWNLOAD_URL + fileId,
-    qs : {
-      'access_token': auth.credentials.access_token
-    }
+    fileId,
+    mimeType: 'application/vnd.google-apps.script+json',
   };
 
-  return request.getAsync(options)
-    .spread(function(res, body) {
-      return JSON.parse(body);
+  return new Promise(function(resolve, reject) {
+    drive.files.export(options, (err, res) => {
+      if (err) return reject(Error(err));
+      resolve(res);
     })
+  })
     .then(function(project) {
       if (!project.files) {
         throw 'Looks like there are no files associated with this project. Check the id and try again.';

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "googleapis": "^2.0.5",
     "lodash": "^3.9.3",
     "mkdirp": "^0.5.1",
-    "node-dir": "^0.1.6",
-    "request": "^2.54.0"
+    "node-dir": "^0.1.6"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
We're already using `googleapis.drive` for updating Google Apps Script's content. Let's be consistent and use it for fetching the contents as well.
