### PR TITLE
Commandline args to override default file locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Check out Matt Hessinger's blog post: [Advanced development process with apps](h
 
   Options:
 
+    -c, --credentials <file> Write credentials to <file>. Default: ~/.gapps
     -b, --no-launch-browser  Do not use a local webserver to capture oauth code
                               and instead require copy/paste of key returned in
                               the browser after authorization completes.
@@ -129,6 +130,7 @@ Performs the authentication flow described in the quickstart above.
   Initialize project locally. The external Apps Script project must exist.
 
   Options:
+    -c, --credentials <file>    Read stored credentials from <file>. Default: ~/.gapps
     -k, --key [key]
     -s, --subdir [subdir]
     -o, --overwrite
@@ -142,6 +144,9 @@ Creates `gapps.config.json`, which contains information about your Apps Script p
   Usage: gapps upload|push
 
   Upload back to Google Drive. Run from root of project directory
+
+  Options:
+    -c, --credentials <file>    Read stored credentials from <file>. Default: ~/.gapps
 ```
 
 Upload the project to Google Drive. Sources files from `./src` or the

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Performs the authentication flow described in the quickstart above.
 
   Options:
     -c, --credentials <file>    Read stored credentials from <file>. Default: ~/.gapps
+    -f, --config <file>         Write project configuration to <file>. Default: gapps.config.json
     -k, --key [key]
     -s, --subdir [subdir]
     -o, --overwrite
@@ -147,6 +148,7 @@ Creates `gapps.config.json`, which contains information about your Apps Script p
 
   Options:
     -c, --credentials <file>    Read stored credentials from <file>. Default: ~/.gapps
+    -f, --config <file>         Read project configuration from <file>. Default: gapps.config.json
 ```
 
 Upload the project to Google Drive. Sources files from `./src` or the
@@ -158,6 +160,9 @@ configured subdirectory.
   Usage: gapps deployment oauth-callback-url
 
   Get the OAuth Callback URL for a project
+
+  Options:
+    -f, --config <file>         Read project configuration from <file>. Default: gapps.config.json
 ```
 
 Returns the OAuth Callback URL required by most 3rd-party OAuth services.

--- a/bin/gapps
+++ b/bin/gapps
@@ -11,12 +11,13 @@ program
 
 program
   .command('auth <path/to/client/secret.json>')
+  .option('-c, --credentials <file>', 'Write credentials to <file>. Default: ~/.gapps')
   .option('-b, --no-launch-browser',
     'Do not use a local webserver to capture oauth code and instead require copy/paste')
   .option('-p, --port [port]', 'Port to use for webserver')
   .description('Authorize gapps to use the Google Drive API')
   .action(function(clientSecretPath, options) {
-    require(commands + '/auth')(clientSecretPath, options.launchBrowser)
+    require(commands + '/auth')(clientSecretPath, options.launchBrowser, options.credentials)
       .then(function() {
         process.exit(0);
       });
@@ -24,12 +25,14 @@ program
 
 program
   .command('upload')
+  .option('-c, --credentials <file>', 'Read stored credentials from <file>. Default: ~/.gapps')
   .description('Upload back to an Apps Script project in Google Drive. Run from root of project directory')
   .alias('push')
   .action(require(commands + '/upload'));
 
 program
   .command('init <fileId>')
+  .option('-c, --credentials <file>', 'Read stored credentials from <file>. Default: ~/.gapps')
   .option('-k, --key [key]')
   .option('-s, --subdir [subdir]')
   .option('-o, --overwrite')

--- a/bin/gapps
+++ b/bin/gapps
@@ -26,6 +26,7 @@ program
 program
   .command('upload')
   .option('-c, --credentials <file>', 'Read stored credentials from <file>. Default: ~/.gapps')
+  .option('-f, --config <file>', 'Read project configuration from <file>. Default: gapps.config.json')
   .description('Upload back to an Apps Script project in Google Drive. Run from root of project directory')
   .alias('push')
   .action(require(commands + '/upload'));
@@ -33,6 +34,7 @@ program
 program
   .command('init <fileId>')
   .option('-c, --credentials <file>', 'Read stored credentials from <file>. Default: ~/.gapps')
+  .option('-f, --config <file>', 'Read project configuration from <file>. Default: gapps.config.json')
   .option('-k, --key [key]')
   .option('-s, --subdir [subdir]')
   .option('-o, --overwrite')
@@ -42,6 +44,7 @@ program
 
 program
   .command('oauth-callback-url')
+  .option('-f, --config <file>', 'Read project configuration from <file>. Default: gapps.config.json')
   .description('Get the OAuth Callback URL for a project')
   .action(require(commands + '/oauthCallbackUrl'));
 

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -4,18 +4,17 @@ var OAuth2Client = require('googleapis').auth.OAuth2;
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
 
-var defaults = require('./defaults');
-
-module.exports = function authenticate() {
-  return getCredentials()
+module.exports = function authenticate(storageFile) {
+  return getCredentials(storageFile)
     .then(createAuthClient)
     .catch(function(err) {
       console.log('Error in authenticate module', err);
     });
 };
 
-function getCredentials() {
-  return fs.readFileAsync(defaults.STORAGE_FILE)
+function getCredentials(storageFile) {
+  console.log('Using credentials from ' + storageFile);
+  return fs.readFileAsync(storageFile)
     .then(JSON.parse)
     .catch(SyntaxError, function(e) {
       console.log('Could not parse credentials'.red);

--- a/lib/commands/auth.js
+++ b/lib/commands/auth.js
@@ -12,26 +12,28 @@ var GOOGLE_AUTH_SCOPE = [
   'https://www.googleapis.com/auth/drive.scripts'
 ];
 
-module.exports = function auth(clientSecretPath, withWebserver) {
-  return fs.lstatAsync(defaults.STORAGE_FILE)
+module.exports = function auth(clientSecretPath, withWebserver, storageFileOption) {
+  var storageFile = storageFileOption || defaults.STORAGE_FILE;
+
+  return fs.lstatAsync(storageFile)
     .then(function() {
-      console.log(defaults.STORAGE_FILE + ' already exists. Remove it to re-authenticate node-google-apps-script');
+      console.log(storageFile + ' already exists. Remove it to re-authenticate node-google-apps-script');
       return Promise.resolve();
     })
     .catch(function(err) {
       if (!clientSecretPath) {
-        throw defaults.STORAGE_FILE + ' does not exist yet. Specify a credential file with `--auth ~/Downloads/client_secret_abcd.json`';
+        throw storageFile + ' does not exist yet. Specify a credential file with `--auth ~/Downloads/client_secret_abcd.json`';
       }
-      return performAuthenticationFlow(clientSecretPath, withWebserver);
+      return performAuthenticationFlow(clientSecretPath, withWebserver, storageFile);
     });
 };
 
-function performAuthenticationFlow(clientSecretPath, withWebserver) {
+function performAuthenticationFlow(clientSecretPath, withWebserver, storageFile) {
   return getCredentialsFromFile(clientSecretPath)
       .then(function(credentials) {
         return authenticateWithGoogle(credentials, withWebserver);
       })
-      .then(saveAuthenticationConfig)
+      .then(saveAuthenticationConfig(storageFile))
       .then(cleanUp)
       .then(function() {
         console.log('Successfully Authenticated with Google Drive!'.green);
@@ -119,8 +121,11 @@ function authenticateWithGoogle(credentials, withWebserver) {
   });
 }
 
-function saveAuthenticationConfig(credentials) {
-  return fs.writeFileAsync(defaults.STORAGE_FILE, JSON.stringify(credentials, "", 2));
+function saveAuthenticationConfig(storageFile) {
+  return function(credentials) {
+    console.log('Writing credentials to ' + storageFile);
+    return fs.writeFileAsync(storageFile, JSON.stringify(credentials, "", 2));
+  }
 }
 
 function cleanUp() {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -9,6 +9,7 @@ var defaults = require('../defaults');
 var manifestor = require('../manifestor');
 
 module.exports = function init(fileId, options) {
+  var storageFile = options && options['credentials'] || defaults.STORAGE_FILE;
   var subdir = options.subdir || defaults.DEFAULT_SUBDIR;
   
   if(!fileIdIsValid(fileId)) {
@@ -33,7 +34,7 @@ module.exports = function init(fileId, options) {
       return mkdirp(subdir);
     })
     .then(function(config) {
-      return manifestor.getExternalFiles(fileId)
+      return manifestor.getExternalFiles(fileId, storageFile)
     })
     .map(function(file) {
       return writeExternalFile(file, subdir)

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -9,6 +9,7 @@ var defaults = require('../defaults');
 var manifestor = require('../manifestor');
 
 module.exports = function init(fileId, options) {
+  var configFile = options && options['config'] || defaults.CONFIG_NAME;
   var storageFile = options && options['credentials'] || defaults.STORAGE_FILE;
   var subdir = options.subdir || defaults.DEFAULT_SUBDIR;
   
@@ -24,11 +25,11 @@ module.exports = function init(fileId, options) {
 
   var overwritePromise = options.overwrite ?
     Promise.resolve() :
-    manifestor.throwIfConfig();
+    manifestor.throwIfConfig(configFile);
 
   return overwritePromise
     .then(function() {
-      return manifestor.set(config);
+      return manifestor.set(config, configFile);
     })
     .then(function() {
       return mkdirp(subdir);

--- a/lib/commands/oauthCallbackUrl.js
+++ b/lib/commands/oauthCallbackUrl.js
@@ -1,13 +1,14 @@
 var defaults = require('../defaults');
 var manifestor = require('../manifestor');
 
-module.exports = function() {
-  return manifestor.get()
+module.exports = function(options) {
+  var configFile = options && options['config'] || defaults.CONFIG_NAME;
+  return manifestor.get(configFile)
     .then(function(config) {
       if (config.key) {
         console.log('https://script.google.com/macros/d/' + config.key + '/usercallback');
       } else {
-        console.log('No Project Key provided in ' + defaults.CONFIG_NAME);
+        console.log('No Project Key provided in ' + configFile);
       }
     });
 };

--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -7,21 +7,22 @@ var defaults = require('../defaults');
 var manifestor = require('../manifestor');
 var authenticate = require('../authenticate');
 
-module.exports = function upload() {
+module.exports = function upload(options) {
   console.log('Pushing back up to Google Drive...');
 
   var fileId; // Hold in closure to avoid promise nesting
+  var storageFile = options && options['credentials'] || defaults.STORAGE_FILE;
 
   return manifestor.get()
     .then(function(config) {
       fileId = config.fileId;
-      return manifestor.getExternalFiles(fileId)
+      return manifestor.getExternalFiles(fileId, storageFile)
     })
     .then(function(externalFiles) {
       return manifestor.build(externalFiles);
     })
     .then(function(files) {
-      return sendToGoogle(files, fileId);
+      return sendToGoogle(files, fileId, storageFile);
     })
     .then(function() {
       console.log('The latest files were successfully uploaded to your Apps Script project.'.green);
@@ -31,13 +32,13 @@ module.exports = function upload() {
     });
 };
 
-function sendToGoogle(files, id) {
+function sendToGoogle(files, id, storageFile) {
   if (!files.length) {
     console.log('No Files to upload.'.red);
     throw 'manifest file length is 0';
   }
 
-  return authenticate()
+  return authenticate(storageFile)
     .then(function(auth) {
       var drive = google.drive({ version: 'v2', auth: auth });
       var options = {

--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -11,15 +11,16 @@ module.exports = function upload(options) {
   console.log('Pushing back up to Google Drive...');
 
   var fileId; // Hold in closure to avoid promise nesting
+  var configFile = options && options['config'] || defaults.CONFIG_NAME;
   var storageFile = options && options['credentials'] || defaults.STORAGE_FILE;
 
-  return manifestor.get()
+  return manifestor.get(configFile)
     .then(function(config) {
       fileId = config.fileId;
       return manifestor.getExternalFiles(fileId, storageFile)
     })
     .then(function(externalFiles) {
-      return manifestor.build(externalFiles);
+      return manifestor.build(externalFiles, configFile);
     })
     .then(function(files) {
       return sendToGoogle(files, fileId, storageFile);

--- a/lib/manifestor.js
+++ b/lib/manifestor.js
@@ -54,8 +54,8 @@ function getFileInManifest(files, file) {
   });
 }
 
-function getExternalFiles(fileId) {
-  return authenticate()
+function getExternalFiles(fileId, storageFile) {
+  return authenticate(storageFile)
     .then(function(auth) {
       return getProjectFiles(fileId, auth);
     })

--- a/lib/manifestor.js
+++ b/lib/manifestor.js
@@ -15,8 +15,8 @@ var authenticate = require('./authenticate');
   @param externalFiles {Object} files in the cloud
   @return {Object} manifest
  */
-var build = function(externalFiles) {
-  return getConfig().get('path')
+var build = function(externalFiles, configFile) {
+  return getConfig(configFile).get('path')
     .then(util.getFilesFromDisk)
     .then(function(files) {
 
@@ -93,19 +93,20 @@ function getProjectFiles(fileId, auth) {
     });
 }
 
-function throwIfConfig() {
-  return fs.readFileAsync(defaults.CONFIG_NAME)
+function throwIfConfig(configFile) {
+  return fs.readFileAsync(configFile)
     .then(JSON.parse)
     .then(function() {
-      throw 'Config already exists. Cowardly refusing to overwrite.';
+      throw 'Config file ' + configFile + ' already exists. Cowardly refusing to overwrite.';
     })
     .error(function() {
       // swallow error
     });
 }
 
-function getConfig() {
-  return fs.readFileAsync(defaults.CONFIG_NAME)
+function getConfig(configFile) {
+  console.log('Reading project configuration from ' + configFile);
+  return fs.readFileAsync(configFile)
     .then(JSON.parse)
     .catch(SyntaxError, function(err) {
       console.log('Error parsing config'.red);
@@ -117,8 +118,9 @@ function getConfig() {
     });
 }
 
-function setConfig(config) {
-  return fs.writeFileAsync(defaults.CONFIG_NAME, JSON.stringify(config, "", 2))
+function setConfig(config, configFile) {
+  console.log('Writing project configuration to ' + configFile);
+  return fs.writeFileAsync(configFile, JSON.stringify(config, "", 2))
     .then(function() {
       return config;
     });


### PR DESCRIPTION
These changes allow the user to switch between multiple sets of stored credentials and destinations (eg. test and production) using command line parameters.