### PR TITLE
add check for 'web' property on credentials object

### DIFF
--- a/lib/commands/auth.js
+++ b/lib/commands/auth.js
@@ -46,8 +46,10 @@ function getCredentialsFromFile(clientSecretPath) {
   return fs.readFileAsync(clientSecretPath)
     .then(JSON.parse)
     .then(function(credentials) {
-      if (!credentials.installed) {
+      if (!credentials.installed && !credentials.web) {
         throw 'Path did not include "OAuth 2.0 client ID" credentials. Please check that you downloaded the right JSON credentials.';
+      } else if (!credentials.installed) {
+        credentials.installed = credentials.web; 
       }
       
       // Add important auth information to persist


### PR DESCRIPTION
Add a check for `web` property in the `credentials` object, in case there is no `installed` property. 

With my GApps account from my company the following command continued to fail:

``` sh
$ gapps auth path/to/credentials.json
```
Here is the stack trace:

```
Error running auth command
Unhandled rejection Error: Path did not include "OAuth 2.0 client ID" credentials. Please check that you downloaded the right JSON credentials.
    at Object.ensureErrorObject (/usr/lib/node_modules/node-google-apps-script/node_modules/bluebird/js/main/util.js:261:20)
    at Promise._rejectCallback (/usr/lib/node_modules/node-google-apps-script/node_modules/bluebird/js/main/promise.js:472:22)
    at Promise._settlePromiseFromHandler (/usr/lib/node_modules/node-google-apps-script/node_modules/bluebird/js/main/promise.js:516:17)
    at Promise._settlePromiseAt (/usr/lib/node_modules/node-google-apps-script/node_modules/bluebird/js/main/promise.js:584:18)
    at Promise._settlePromises (/usr/lib/node_modules/node-google-apps-script/node_modules/bluebird/js/main/promise.js:700:14)
    at Async._drainQueue (/usr/lib/node_modules/node-google-apps-script/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/usr/lib/node_modules/node-google-apps-script/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues (/usr/lib/node_modules/node-google-apps-script/node_modules/bluebird/js/main/async.js:15:14)
    at runCallback (timers.js:651:20)
    at tryOnImmediate (timers.js:624:5)
    at processImmediate [as _immediateCallback] (timers.js:596:5)
```