### PR TITLE
feat(*): support uploading 'folders' to gapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ If you want to develop, clone down the repo and have at it! You can run `npm lin
 
 ## Limitations
 
-`gapps` allows you to nest files in folders, but the Apps Script platform expects a flat file structure. Because of this, **no files can have the same name, even if they are in separate directories**. One file will overwrite the other, making debugging difficult.
-
 Your add-on must be developed as a [standalone script](https://developers.google.com/apps-script/guides/standalone)
 and tested within Doc or Sheet. This means that it cannot use certain functions of [bound scripts](https://developers.google.com/apps-script/guides/bound), namely installable triggers. While testing within a Doc, you have access to the
 "Special methods" mentioned in [the docs](https://developers.google.com/apps-script/guides/bound), though. If

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,7 +1,8 @@
 var colors = require('colors');
-var mkdirp = require('mkdirp');
-
 var Promise = require('bluebird');
+var path = require('path');
+
+var mkdirp = Promise.promisify(require('mkdirp'));
 var fs = Promise.promisifyAll(require('fs'));
 
 var util = require('../util')
@@ -10,11 +11,11 @@ var manifestor = require('../manifestor');
 
 module.exports = function init(fileId, options) {
   var subdir = options.subdir || defaults.DEFAULT_SUBDIR;
-  
+
   if(!fileIdIsValid(fileId)) {
     return;
   }
-  
+
   var config = {
     path: subdir,
     fileId: fileId,
@@ -46,7 +47,10 @@ module.exports = function init(fileId, options) {
 
 function writeExternalFile(file, dir) {
   var filename = file.name + util.getFileExtension(file)
-  return fs.writeFileAsync(dir + '/' + filename, file.source)
+  return mkdirp(path.join(dir, path.dirname(filename)))
+    .then(function () {
+      return fs.writeFileAsync(dir + '/' + filename, file.source)
+    })
     .catch(function(err) {
       console.log('Could not write file ' + filename);
       throw err;

--- a/lib/manifestor.js
+++ b/lib/manifestor.js
@@ -32,7 +32,7 @@ var build = function(externalFiles) {
         if (manifestFile === undefined) {
           // add
           filesToUpload.push({
-            name: file.name,
+            name: file.fullName,
             type: util.getFileType(file),
             source: file.content
           });
@@ -49,7 +49,7 @@ var build = function(externalFiles) {
 
 function getFileInManifest(files, file) {
   return _.findWhere(files, {
-    name: file.name,
+    name: file.fullName,
     type: util.getFileType(file)
   });
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,6 +17,10 @@ function getFilesFromDisk(subdir) {
         // Parse file's absolute path and add its content to result object
         file = path.parse(filename);
         file.content = content;
+        file.fullName = path.relative(subdir, file.dir) + '/' + file.name;
+        if (file.fullName[0] === '/') {
+          file.fullName = file.fullName.substring(1);
+        }
 
         filesOnDisk.push(file);
 
@@ -39,10 +43,10 @@ function updateFileSource(existingFile, newFile) {
   existingFile.source = newFile.content;
 }
 
-function hasFileOnDisk(filesOnDisk, file) {
+function hasFileOnDisk(filesOnDisk, fileOnline) {
   return _.any(filesOnDisk, function(fileOnDisk) {
-    var sameName = file.name === fileOnDisk.name;
-    var sameType = file.type === getFileType(fileOnDisk);
+    var sameName = fileOnline.name === fileOnDisk.fullName;
+    var sameType = fileOnline.type === getFileType(fileOnDisk);
     return sameName && sameType;
   });
 }


### PR DESCRIPTION
This PR adds the ability to handle folders properly when uploading files to Google Apps Script, without resorting to flattening the file tree.

Files on Google Apps Script seem to allow the `/` character in their name and so this PR exploits this to enable support of folders.  
Files that are found in folders simply get their folders prepended to their name, and therefore: folder support.

