### PR TITLE
chore(util.js): remove useless swapGStoJS function from util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -60,17 +60,9 @@ function getFileExtension(file) {
   throw new Error('Unsupported file type found');
 }
 
-function swapGStoJS(filename) {
-  if (filename.indexOf('.gs') === filename.length - 3) {
-    return filename.substr(0, filename.lastIndexOf('.gs')) + '.js';
-  }
-  return filename;
-}
-
 
 module.exports.getFilesFromDisk = getFilesFromDisk;
 module.exports.updateFileSource = updateFileSource;
 module.exports.hasFileOnDisk = hasFileOnDisk;
 module.exports.getFileType = getFileType;
 module.exports.getFileExtension = getFileExtension;
-module.exports.swapGStoJS = swapGStoJS;


### PR DESCRIPTION
I saw this function in `util.js` that wasn't used anywhere, so thought I'd delete it.