### PR TITLE
TeamDrive functionality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 The branch works for scripts sitting in a Team Drive by adding the parameter supportsTeamDrives to the upload request. 
 
 * Moving the script to a team drive causes https://github.com/danthareja/node-google-apps-script to fail uploading 
-* This may be because the update command wants a parameter `supportTeamDrives` set to true, see https://developers.google.com/apis-explorer/?hl=en_US#p/drive/v3/drive.files.update  and https://developers.google.com/drive/v3/reference/files/update
+* This is because the update command wants a parameter `supportTeamDrives` set to true, see https://developers.google.com/apis-explorer/?hl=en_US#p/drive/v3/drive.files.update  and https://developers.google.com/drive/v3/reference/files/update
 * https://developers.google.com/drive/v3/web/enable-teamdrives  : “If your application isn't affected by the behavioral differences, then you only need to include thesupportsTeamDrives=true query parameter in requests. This is an acknowledgement that the application is aware of behavioral differences of files contained in Team Drives.”
 * Adding  `supportsTeamDrives: true` to 
   ```return authenticate()

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ The branch works for scripts sitting in a Team Drive by adding the parameter sup
 	          mimeType: 'application/vnd.google-apps.script+json',
 	          body: JSON.stringify({ files: files })
 	        }
-	      }; 
-```
+	      }; ```
 fixes the problem for a team drive
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+The branch works for scripts sitting in a Team Drive by adding the parameter supportsTeamDrives to the upload request. 
+
+* Moving the script to a team drive causes https://github.com/danthareja/node-google-apps-script to fail uploading 
+* This may be because the update command wants a parameter `supportTeamDrives` set to true, see https://developers.google.com/apis-explorer/?hl=en_US#p/drive/v3/drive.files.update  and https://developers.google.com/drive/v3/reference/files/update
+* https://developers.google.com/drive/v3/web/enable-teamdrives  : “If your application isn't affected by the behavioral differences, then you only need to include thesupportsTeamDrives=true query parameter in requests. This is an acknowledgement that the application is aware of behavioral differences of files contained in Team Drives.”
+* Adding  `supportsTeamDrives: true` to 
+  ```return authenticate()
+	    .then(function(auth) {
+	      var drive = google.drive({ version: 'v2', auth: auth });
+	      var options = {
+	        fileId: id,
+	        supportsTeamDrives: true,
+	        media: {
+	          mimeType: 'application/vnd.google-apps.script+json',
+	          body: JSON.stringify({ files: files })
+	        }
+	      }; 
+```
+fixes the problem for a team drive
+
+
+
 # gapps (Google Apps Script)
 >The easiest way to develop Google Apps Script projects
 

--- a/bin/gapps
+++ b/bin/gapps
@@ -24,6 +24,7 @@ program
 
 program
   .command('upload')
+  .option('-t, --teamdrive')
   .description('Upload back to an Apps Script project in Google Drive. Run from root of project directory')
   .alias('push')
   .action(require(commands + '/upload'));

--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -7,7 +7,8 @@ var defaults = require('../defaults');
 var manifestor = require('../manifestor');
 var authenticate = require('../authenticate');
 
-module.exports = function upload() {
+module.exports = function upload(options) {
+  // console.log(options)
   console.log('Pushing back up to Google Drive...');
 
   var fileId; // Hold in closure to avoid promise nesting
@@ -21,7 +22,7 @@ module.exports = function upload() {
       return manifestor.build(externalFiles);
     })
     .then(function(files) {
-      return sendToGoogle(files, fileId);
+      return sendToGoogle(files, fileId, options.teamdrive);
     })
     .then(function() {
       console.log('The latest files were successfully uploaded to your Apps Script project.'.green);
@@ -31,7 +32,7 @@ module.exports = function upload() {
     });
 };
 
-function sendToGoogle(files, id) {
+function sendToGoogle(files, id, supportsTeamDrives) {
   if (!files.length) {
     console.log('No Files to upload.'.red);
     throw 'manifest file length is 0';
@@ -39,16 +40,20 @@ function sendToGoogle(files, id) {
 
   return authenticate()
     .then(function(auth) {
-      var drive = google.drive({ version: 'v2', auth: auth });
       var options = {
         fileId: id,
-        supportsTeamDrives: true,
         media: {
           mimeType: 'application/vnd.google-apps.script+json',
           body: JSON.stringify({ files: files })
         }
       };
 
+      if (supportsTeamDrives) {
+        console.log('teamdrive=true')
+        options.supportsTeamDrives = true;
+      }
+
+      var drive = google.drive({ version: 'v2', auth: auth });
       return Promise.promisify(drive.files.update)(options)
         .catch(function(err) {
           console.log('An error occured while running upload command: '.red + err.message);

--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -42,6 +42,7 @@ function sendToGoogle(files, id) {
       var drive = google.drive({ version: 'v2', auth: auth });
       var options = {
         fileId: id,
+        supportsTeamDrives: true,
         media: {
           mimeType: 'application/vnd.google-apps.script+json',
           body: JSON.stringify({ files: files })


### PR DESCRIPTION
The branch works for scripts sitting in a Team Drive by adding the parameter supportsTeamDrives to the upload request. 

* Moving the google apps script to a team drive causes https://github.com/danthareja/node-google-apps-script to fail uploading 
* This is because google expects a parameter `supportTeamDrives` set to true, see https://developers.google.com/apis-explorer/?hl=en_US#p/drive/v3/drive.files.update  and https://developers.google.com/drive/v3/reference/files/update
* https://developers.google.com/drive/v3/web/enable-teamdrives  : “If your application isn't affected by the behavioral differences, then you only need to include thesupportsTeamDrives=true query parameter in requests. This is an acknowledgement that the application is aware of behavioral differences of files contained in Team Drives.”
* Adding  `supportsTeamDrives: true` to 
  ```return authenticate()
	    .then(function(auth) {
	      var drive = google.drive({ version: 'v2', auth: auth });
	      var options = {
	        fileId: id,
	        supportsTeamDrives: true,
	        media: {
	          mimeType: 'application/vnd.google-apps.script+json',
	          body: JSON.stringify({ files: files })
	        }
	      }; ```
fixes the problem for a team drive

I've added this as an addition option. I.e. 
```
gapps push --teamdrive 
```
