### PR TITLE
Issue 57: return after resolving get token failure

### DIFF
--- a/lib/commands/auth.js
+++ b/lib/commands/auth.js
@@ -85,7 +85,7 @@ function authenticateWithGoogle(credentials, withWebserver) {
 
     var getToken = function(code) {
       oauth2Client.getToken(code, function(err, tokens) {
-        if (err) { reject(err); }
+        if (err) { reject(err); return; }
         credentials.refresh_token = tokens.refresh_token;
         resolve(credentials);
       });


### PR DESCRIPTION
Returns to avoid setting credentials on getToken failure.