### PR TITLE
Fix auth test

### DIFF
--- a/__mocks__/googleapis.js
+++ b/__mocks__/googleapis.js
@@ -1,0 +1,12 @@
+// Get the genuine googleapis library:
+const googleapis = require.requireActual('googleapis');
+
+// Override the getToken with a mock (we don't want to hit Google's servers in our tests)
+googleapis.auth.OAuth2.prototype.getToken = (code, cb) => {
+  console.log("googleapis.auth.OAuth2 getToken called with code " + code);
+  cb(null, {
+    refresh_token: "woot_successfully_obtained_refresh_token"
+  });
+};
+
+module.exports = googleapis;

--- a/lib/__mocks__/miniOAuthServer.js
+++ b/lib/__mocks__/miniOAuthServer.js
@@ -1,0 +1,8 @@
+const url = require('url');
+const http = require('http');
+const Promise = require('bluebird');
+
+module.exports = async function createOAuthServerMock(port) {
+  console.log("createOAuthServerMock with port " + port);
+  return Promise.resolve("oauth_code_acquired_through_authentication_flow");
+};


### PR DESCRIPTION
This fixes the `auth` command test by mocking:

* `miniOauthServer`, because it hangs indefinitely even when the test is finished (it is mocked by an instantly resolving promise simulating the user being returned from the oauth flow to the oauth callback)
* `googleapis.auth.OAuth2.prototype.getToken` because we want to be able to simulate a call to Google's token endpoint and make assertions on the token that was acquired